### PR TITLE
Add shodan search count before actually querying with net: filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,8 +115,8 @@ func gatherIPsToSearch(sclient *shodan.Client, filename string) ([]string, error
 							ips = append(ips, netIPs...)
 							lk.Unlock()
 						}
+						time.Sleep(5*time.Second)
 					}
-					time.Sleep(5*time.Second)
 				}
 				wg.Done()
 			}(*sclient)


### PR DESCRIPTION
Hey, I bought shodan developer API plan a few days ago and trying to play with drone-shodan. This PR is not expected to be merged but highlight couple ideas that came over my head while using it. Hope someone will find it useful.

Official documentation [says](https://developer.shodan.io/api) that credits are deducted on search query filter usage and/or when additional pages with results are viewed. When enumerating lots of subnets (using net filter) it is usual to see shodan responses with 0 hosts in it, so credits just getting wasted.

Although I hadn't noticed credits deduction, I decided to prepare drone for this. Request to /shodan/host/search firstly is available to avoid that cases, but it leads us to make x2 requests for every subnet. To address this slow down 10 goroutines will be started for processing nets to ips.

Main function was a little reorganized to separate actually hosts quering from getting initial list of hosts which is now in gatherIPsToSearch function. It could be expanded in future to handle not only IPs and subnets but also domain names etc.